### PR TITLE
Set database default tablespace to USERS, not SYSTEM

### DIFF
--- a/puppet/modules/oracle/files/create_rails_users.sql
+++ b/puppet/modules/oracle/files/create_rails_users.sql
@@ -1,3 +1,5 @@
+ALTER DATABASE DEFAULT TABLESPACE USERS;
+
 CREATE USER oracle_enhanced IDENTIFIED BY oracle_enhanced;
 
 GRANT unlimited tablespace, create session, create table, create sequence,


### PR DESCRIPTION
https://github.com/rsim/oracle-enhanced/pull/1034 changed value of default tablespace on Travis CI test environment.

I want to use this PR changes at spec of https://github.com/rsim/oracle-enhanced/pull/1028.

This PR will make the query output below.

```sh
SQL> SELECT username, default_tablespace FROM user_users;

USERNAME                       DEFAULT_TABLESPACE
------------------------------ ------------------------------
ORACLE_ENHANCED                USERS
```

How about that?
