### PR TITLE
Use Ruby 2.5.0

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -140,7 +140,7 @@ exec { 'install_ruby':
   # The rvm executable is more suitable for automated installs.
   #
   # Thanks to @mpapis for this tip.
-  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.4.2 --autolibs=enabled && rvm --fuzzy alias create default 2.4.2'",
+  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.5.0 --autolibs=enabled && rvm --fuzzy alias create default 2.5.0'",
   creates => "${home}/.rvm/bin/ruby",
   require => Exec['install_rvm']
 }


### PR DESCRIPTION
Ruby 2.5.0 has been released.
https://www.ruby-lang.org/ja/news/2017/12/25/ruby-2-5-0-released/

```console
% vagrant provision
% vagrant ssh
vagrant@rails-dev-box:~$ ruby -v
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux]
```