### PR TITLE
Use cloud URL instead of filestorage URL for VM box.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,5 @@
 Vagrant.configure('2') do |config|
-  config.vm.box      = 'precise64'
-  config.vm.box_url  = 'http://files.vagrantup.com/precise64.box'
+  config.vm.box      = 'hashicorp/precise64'
   config.vm.hostname = 'rails-dev-box'
 
   config.vm.network :forwarded_port, guest: 3000, host: 3000


### PR DESCRIPTION
- `vagrant up` times out due to `hashicorp-files.hashicorp.com` being down.
- Looking at this comment
  (https://github.com/hashicorp/vagrant/issues/9847#issuecomment-390270996),
  looks like files from `http://files.vagrantup.com/` and
  `hashicorp-files.hashicorp.com` have been moved to the cloud.
- The `precise64` package can be found at
  `https://app.vagrantup.com/hashicorp/boxes/precise64` `vagrant up` works as
  expected.