### PR TITLE
Use Ruby 2.6.0

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -140,12 +140,12 @@ exec { 'install_ruby':
   # The rvm executable is more suitable for automated installs.
   #
   # Thanks to @mpapis for this tip.
-  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.5.1 --autolibs=enabled && rvm --fuzzy alias create default 2.5.1'",
+  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.6.0 --autolibs=enabled && rvm --fuzzy alias create default 2.6.0'",
   creates => "${home}/.rvm/bin/ruby",
   require => Exec['install_rvm']
 }
 
-exec { "${as_vagrant} 'gem install bundler --no-rdoc --no-ri'":
+exec { "${as_vagrant} 'gem install bundler --no-document'":
   creates => "${home}/.rvm/bin/bundle",
   require => Exec['install_ruby']
 }


### PR DESCRIPTION
Ruby 2.6.0 has been released.
https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/

And `--no-rdoc` option and `--no-ri` option are removed in RubyGems 3.0,
they are replaced with `--no-document` option.

```console
% vagrant provision
% vagrant ssh
vagrant@rails-dev-box:~$ ruby -v
ruby 2.6.0p0 (2018-12-25 revision 66547) [x86_64-linux]
vagrant@rails-dev-box:~$ gem -v
3.0.1
vagrant@rails-dev-box:~$ bundle -v
Bundler version 2.0.1
```