### PR TITLE
Use Ruby 2.6.1

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -140,7 +140,7 @@ exec { 'install_ruby':
   # The rvm executable is more suitable for automated installs.
   #
   # Thanks to @mpapis for this tip.
-  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.6.0 --autolibs=enabled && rvm --fuzzy alias create default 2.6.0'",
+  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.6.1 --autolibs=enabled && rvm --fuzzy alias create default 2.6.1'",
   creates => "${home}/.rvm/bin/ruby",
   require => Exec['install_rvm']
 }


### PR DESCRIPTION
Ruby 2.6.1 has been released.
https://www.ruby-lang.org/en/news/2019/01/30/ruby-2-6-1-released

```console
% vagrant provision
% vagrant ssh
vagrant@rails-dev-box:~/src$ ruby -v
ruby 2.6.1p33 (2019-01-30 revision 66950) [x86_64-linux]
```