### PR TITLE
Use Ruby 2.6.2

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -140,7 +140,7 @@ exec { 'install_ruby':
   # The rvm executable is more suitable for automated installs.
   #
   # Thanks to @mpapis for this tip.
-  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.6.1 --autolibs=enabled && rvm --fuzzy alias create default 2.6.1'",
+  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.6.2 --autolibs=enabled && rvm --fuzzy alias create default 2.6.2'",
   creates => "${home}/.rvm/bin/ruby",
   require => Exec['install_rvm']
 }


### PR DESCRIPTION
Ruby 2.6.2 has been released.
https://www.ruby-lang.org/en/news/2019/03/13/ruby-2-6-2-released/

```console
% vagrant provision
% vagrant ssh
$ ruby -v
ruby 2.6.2p47 (2019-03-13 revision 67232) [x86_64-linux]
```