### PR TITLE
Use Ruby 2.6.4

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -140,7 +140,7 @@ exec { 'install_ruby':
   # The rvm executable is more suitable for automated installs.
   #
   # Thanks to @mpapis for this tip.
-  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.6.3 --autolibs=enabled && rvm --fuzzy alias create default 2.6.3'",
+  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.6.4 --autolibs=enabled && rvm --fuzzy alias create default 2.6.4'",
   creates => "${home}/.rvm/bin/ruby",
   require => Exec['install_rvm']
 }


### PR DESCRIPTION
Ruby 2.6.4 has been released.
https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-6-4-released/

```console
% vagrant provision
% vagrant ssh
$ ruby -v
ruby 2.6.4p104 (2019-08-28 revision 67798) [x86_64-linux]
```