### PR TITLE
Use Ruby 2.6.5

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -140,7 +140,7 @@ exec { 'install_ruby':
   # The rvm executable is more suitable for automated installs.
   #
   # Thanks to @mpapis for this tip.
-  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.6.4 --autolibs=enabled && rvm --fuzzy alias create default 2.6.4'",
+  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.6.5 --autolibs=enabled && rvm --fuzzy alias create default 2.6.5'",
   creates => "${home}/.rvm/bin/ruby",
   require => Exec['install_rvm']
 }


### PR DESCRIPTION
Ruby 2.6.5 has been released.
https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/

```console
% vagrant provision
% vagrant ssh
$ ruby -v
ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-linux]
```