### PR TITLE
Use Ruby 2.7.1

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -140,7 +140,7 @@ exec { 'install_ruby':
   # The rvm executable is more suitable for automated installs.
   #
   # Thanks to @mpapis for this tip.
-  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.7.0 --autolibs=enabled && rvm --fuzzy alias create default 2.7.0'",
+  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.7.1 --autolibs=enabled && rvm --fuzzy alias create default 2.7.1'",
   creates => "${home}/.rvm/bin/ruby",
   require => Exec['install_rvm']
 }


### PR DESCRIPTION
Ruby 2.7.1 has been released.
https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-7-1-released/

```console
% vagrant provision
% vagrant ssh
$ ruby -v
ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-linux]
```