### PR TITLE
Use Ruby 2.7.2

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -140,7 +140,7 @@ exec { 'install_ruby':
   # The rvm executable is more suitable for automated installs.
   #
   # Thanks to @mpapis for this tip.
-  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.7.1 --autolibs=enabled && rvm --fuzzy alias create default 2.7.1'",
+  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.7.2 --autolibs=enabled && rvm --fuzzy alias create default 2.7.2'",
   creates => "${home}/.rvm/bin/ruby",
   require => Exec['install_rvm']
 }


### PR DESCRIPTION
Ruby 2.7.2 has been released.
https://www.ruby-lang.org/en/news/2020/10/02/ruby-2-7-2-released/

```console
% vagrant provision
% vagrant ssh
$ ruby -v
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]
```